### PR TITLE
Check if the dll has already been copied

### DIFF
--- a/src/AutoHotkey.Interop/Util/EmbededResourceHelper.cs
+++ b/src/AutoHotkey.Interop/Util/EmbededResourceHelper.cs
@@ -29,6 +29,7 @@ namespace AutoHotkey.Interop.Util
         
 
         public static void ExtractToFile(Assembly assembly, string embededResourceName, string outputFilePath) {
+            if (File.Exists(outputFilePath)) return;
             string full_resource_name = FindByName(assembly, embededResourceName);
 
             if (full_resource_name == null)


### PR DESCRIPTION
The dll has already copied and it is used(read) by a process, but when a second process starts to run, it tried to copy the dll again and it ended up with an IO error.

I have allowed two or more processes to run by the copy procedure to skip if the file already exists at the destination.